### PR TITLE
Add low traffic channel monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ To support DALL-E 3 image generation, also add your OpenAI API key to secrets.en
 export OPENAI_API_KEY=paste API key here
 ```
 
+### Low traffic channels
+
+If you have channels that are intended to stay quiet, list their IDs in the
+`LOW_TRAFFIC_CHANNELS` environment variable, separated by commas.
+
+```bash
+export LOW_TRAFFIC_CHANNELS=1234567890123456,9876543210987654
+```
+
 ### Prod
 
 To run the prod build, run ./run_prod.sh, which will kill any previous prod hypnos processes and start hypnos as a daemon logging to `nohup.out`, then tail that file in your current terminal. Quitting the tail will not stop hypnos.

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,18 @@ mod data;
 mod dice;
 mod info;
 mod sparkle;
+use std::time::Duration;
 use poise::serenity_prelude as serenity;
+use poise::Event;
 
 #[tokio::main]
 async fn main() {
     let framework = poise::Framework::builder()
         .options(poise::FrameworkOptions {
             commands: vec![dice::roll(), dalle::gen(), sparkle::shimmer(), info::info()],
+            event_handler: |_ctx, event, framework, data| {
+                Box::pin(event_handler(_ctx, event, framework, data))
+            },
             ..Default::default()
         })
         .token(std::env::var("DISCORD_TOKEN").expect("missing DISCORD_TOKEN env variable"))
@@ -35,4 +40,46 @@ async fn main() {
         });
     println!("Starting bot...");
     framework.run().await.unwrap();
+}
+
+async fn event_handler(
+    ctx: &serenity::Context,
+    event: &Event<'_>,
+    _framework: poise::FrameworkContext<'_, data::Data, data::Error>,
+    data: &data::Data,
+) -> Result<(), data::Error> {
+    if let Event::Message { new_message } = event {
+        if new_message.author.bot {
+            return Ok(());
+        }
+        if data.low_traffic_channels.contains(&new_message.channel_id) {
+            use std::time::Instant;
+            let mut state = data.low_traffic_state.lock().await;
+            let now = Instant::now();
+            let entries = state.messages.entry(new_message.channel_id).or_default();
+            entries.push(now);
+            let limit = Duration::from_secs(5 * 60);
+            entries.retain(|t| now.duration_since(*t) <= limit);
+            if entries.len() > 3 {
+                let warn = match state.last_warned.get(&new_message.channel_id) {
+                    Some(last) if now.duration_since(*last) < limit => false,
+                    _ => true,
+                };
+                if warn {
+                    if let Err(err) = new_message
+                        .channel_id
+                        .say(
+                            &ctx.http,
+                            "This channel is meant to be low traffic. Please continue the conversation elsewhere.",
+                        )
+                        .await
+                    {
+                        println!("Failed to send low traffic warning: {}", err);
+                    }
+                    state.last_warned.insert(new_message.channel_id, now);
+                }
+            }
+        }
+    }
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- warn if a chatty channel is supposed to be low traffic
- read LOW_TRAFFIC_CHANNELS env var to get list of quiet channels
- document new environment variable

## Testing
- `cargo check`