### PR TITLE
Add unit tests

### DIFF
--- a/src/dalle.rs
+++ b/src/dalle.rs
@@ -295,3 +295,42 @@ impl Image {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dimensions_to_size() {
+        assert_eq!(Dimensions::Square.to_size(), "1024x1024");
+        assert_eq!(Dimensions::Wide.to_size(), "1792x1024");
+        assert_eq!(Dimensions::Tall.to_size(), "1024x1792");
+    }
+
+    #[test]
+    fn test_quality_to_str() {
+        assert_eq!(Quality::Standard.to_str(), "standard");
+        assert_eq!(Quality::HD.to_str(), "hd");
+    }
+
+    #[test]
+    fn test_style_to_str() {
+        assert_eq!(Style::Natural.to_str(), "natural");
+        assert_eq!(Style::Vivid.to_str(), "vivid");
+    }
+
+    #[test]
+    fn test_image_request_cost() {
+        let req = ImageRequest {
+            description: "desc".to_string(),
+            num: 2,
+            dimensions: Dimensions::Square,
+            style: Style::Vivid,
+            quality: Quality::Standard,
+        };
+        let cost = req.cost();
+        let v = serde_json::to_value(cost).unwrap();
+        assert_eq!(v["millicents"], serde_json::json!(8000));
+        assert_eq!(req.num_images(), 2);
+    }
+}

--- a/src/data.rs
+++ b/src/data.rs
@@ -140,3 +140,40 @@ impl Cost {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_low_traffic_channels_empty() {
+        std::env::remove_var("LOW_TRAFFIC_CHANNELS");
+        let channels = parse_low_traffic_channels();
+        assert!(channels.is_empty());
+    }
+
+    #[test]
+    fn test_parse_low_traffic_channels_some() {
+        std::env::set_var("LOW_TRAFFIC_CHANNELS", "1, 2 ,3");
+        let channels = parse_low_traffic_channels();
+        assert_eq!(channels.len(), 3);
+        assert_eq!(channels[0].0, 1);
+        assert_eq!(channels[1].0, 2);
+        assert_eq!(channels[2].0, 3);
+        std::env::remove_var("LOW_TRAFFIC_CHANNELS");
+    }
+
+    #[test]
+    fn test_cost_cents() {
+        let c = Cost::cents(5);
+        assert_eq!(c.millicents, 5000);
+    }
+
+    #[test]
+    fn test_account_overdrafted() {
+        let acc = Account { user: String::new(), images: 0, credit: -1, total_cost: 0 };
+        assert!(acc.overdrafted());
+        let acc = Account { user: String::new(), images: 0, credit: 1, total_cost: 0 };
+        assert!(!acc.overdrafted());
+    }
+}

--- a/src/dice.rs
+++ b/src/dice.rs
@@ -268,3 +268,71 @@ enum CortexResult {
     Botch,
     Result { total: u64, effect: Die },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_die_count_simple() {
+        assert_eq!(
+            DiceRollRequest::get_die_count("d6"),
+            Some((1, Die { sides: 6 }))
+        );
+    }
+
+    #[test]
+    fn test_get_die_count_number_only() {
+        assert_eq!(
+            DiceRollRequest::get_die_count("8"),
+            Some((1, Die { sides: 8 }))
+        );
+    }
+
+    #[test]
+    fn test_get_die_count_invalid() {
+        assert_eq!(DiceRollRequest::get_die_count("foo"), None);
+    }
+
+    #[test]
+    fn test_parse_too_many() {
+        let err = DiceRollRequest::parse("1000001d6");
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn test_is_botch() {
+        let rr = RollResult {
+            rolled_die: vec![
+                Roll::Glitch(Die { sides: 6 }),
+                Roll::Glitch(Die { sides: 6 }),
+            ],
+        };
+        assert!(rr.is_botch());
+    }
+
+    #[test]
+    fn test_get_highest_effect_and_total() {
+        let mut rr = RollResult {
+            rolled_die: vec![
+                Roll::Value(1, Die { sides: 4 }),
+                Roll::Value(2, Die { sides: 6 }),
+                Roll::Value(3, Die { sides: 8 }),
+            ],
+        };
+        assert_eq!(
+            rr.get_highest_effect(),
+            CortexResult::Result {
+                total: 3,
+                effect: Die { sides: 8 }
+            }
+        );
+        assert_eq!(
+            rr.get_highest_total(),
+            CortexResult::Result {
+                total: 5,
+                effect: Die { sides: 4 }
+            }
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add thorough test coverage for dice rolling helpers
- cover data helpers like low traffic parsing and cost
- check DALLE request helpers

## Testing
- `cargo test -- --nocapture`