### PR TITLE
Add integration test with fake OpenAI server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,9 @@ serde = { version = "1.0.193", features = ["std", "derive"]}
 base64 = "0.21.5"
 reqwest = "0.11.22"
 
+[dev-dependencies]
+tokio = { version = "1.34.0", features = ["macros", "rt-multi-thread"] }
+hyper = { version = "0.14.27", features = ["full"] }
+
 [profile.dev]
 split-debuginfo = "unpacked"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod dalle;
+pub mod data;
+pub mod dice;
+pub mod info;
+pub mod sparkle;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,4 @@
-mod dalle;
-mod data;
-mod dice;
-mod info;
-mod sparkle;
+use hypnos::{dalle, data, dice, info, sparkle};
 use std::time::Duration;
 use poise::serenity_prelude as serenity;
 use poise::Event;

--- a/tests/dalle_integration.rs
+++ b/tests/dalle_integration.rs
@@ -1,0 +1,42 @@
+use hypnos::dalle::{ImageRequest, Dimensions, Style, Quality, OpenAIImageGen};
+use hyper::{Body, Request, Response, Server};
+use hyper::service::{make_service_fn, service_fn};
+
+#[tokio::test]
+async fn test_create_image_uses_fake_server() {
+    // start a simple hyper server that returns a fixed response
+    let make_svc = make_service_fn(|_conn| async {
+        Ok::<_, hyper::Error>(service_fn(|_req: Request<Body>| async move {
+            let body = "{\"data\": [{\"revised_prompt\": \"hi\", \"b64_json\": \"aGVsbG8=\"}]}";
+            Ok::<_, hyper::Error>(
+                Response::builder()
+                    .status(200)
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+        }))
+    });
+
+    let server = Server::bind(&([127,0,0,1], 0).into()).serve(make_svc);
+    let addr = server.local_addr();
+    let handle = tokio::spawn(server);
+
+    std::env::set_var("OPENAI_API_KEY", "test-key");
+    std::env::set_var("OPENAI_IMAGE_GEN_URL", format!("http://{}/v1/images/generations", addr));
+
+    let gen = OpenAIImageGen::new().unwrap();
+    let req = ImageRequest::new(
+        "hello".to_string(),
+        1,
+        Dimensions::Square,
+        Style::Vivid,
+        Quality::Standard,
+    );
+
+    let images = gen.create_image(req).await.unwrap();
+    assert_eq!(images.len(), 1);
+    assert!(images[0].is_ok());
+
+    handle.abort();
+}


### PR DESCRIPTION
## Summary
- expose internal modules through a new library crate
- make OpenAI image generator configurable and public
- allow creating image requests from tests
- add integration test using a local Hyper server to fake OpenAI

## Testing
- `cargo test`