### PR TITLE
Add Nix flake and GitHub Actions workflow

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,22 @@
+name: Nix Build and Test
+
+on:
+  push:
+    branches: [ "main" ] # Or your default branch
+  pull_request:
+    branches: [ "main" ] # Or your default branch
+
+jobs:
+  build-and-test-with-nix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v4 # Using v4, check for latest if preferred
+
+      - name: Build hypnos binary with Nix
+        run: nix build .#hypnos
+
+      - name: Run tests with Nix
+        run: nix flake check

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 secrets.env
 nohup.out
 /image*.png
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1748370509,
+        "narHash": "sha256-QlL8slIgc16W5UaI3w7xHQEP+Qmv/6vSNTpoZrrSlbk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4faa5f5321320e49a78ae7848582f684d64783e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1748399823,
+        "narHash": "sha256-kahD8D5hOXOsGbNdoLLnqCL887cjHkx98Izc37nDjlA=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "d68a69dc71bc19beb3479800392112c2f6218159",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,85 @@
+{
+  description = "A Nix flake for the hypnos project";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, rust-overlay, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+        rustVersion = pkgs.rust-bin.stable."1.75.0".default; # Adjust version as needed
+      in
+      with pkgs;
+      {
+        packages = rec {
+          hypnos = pkgs.rustPlatform.buildRustPackage {
+            pname = "hypnos";
+            version = "1.2.1"; # Should match Cargo.toml
+
+            src = ./.;
+
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+            };
+
+            nativeBuildInputs = [
+              pkg-config
+            ];
+
+            buildInputs = [
+              openssl
+              # Add other system dependencies if needed by your Rust crates
+            ];
+
+            # If your tests require network access or other special conditions,
+            # you might need to configure them here.
+            # By default, `cargo test` is run.
+          };
+          default = hypnos;
+        };
+
+        checks = {
+          # Run tests
+          hypnos-tests = self.packages.${system}.hypnos.overrideAttrs (oldAttrs: {
+            # The buildRustPackage already runs `cargo test` by default
+            # if you need to customize it, you can do it here.
+            # For example, to pass specific arguments to cargo test:
+            # buildPhase = ''
+            #   runHook preBuild
+            #   cargo test --verbose -- --skip some_integration_test
+            #   runHook postBuild
+            # '';
+            # Or to ensure tests are run in a specific environment:
+            # checkPhase = ''
+            #  export SOME_ENV_VAR="value"
+            #  cargo test --verbose
+            # '';
+          });
+          default = self.checks.${system}.hypnos-tests;
+        };
+
+        devShells.default = mkShell {
+          useLLVM = true;
+          packages = [
+            rustVersion
+            cargo
+            rustfmt
+            clippy
+            rust-analyzer
+            openssl
+            pkg-config
+            # Add other development tools here
+          ];
+          # Environment variables for the shell
+          RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
+        };
+      }
+    );
+}


### PR DESCRIPTION
This commit introduces a Nix flake (`flake.nix`) to define a reproducible build environment for the `hypnos` binary and its tests.

It also adds a new GitHub Actions workflow (`.github/workflows/nix.yml`) that uses this Nix flake to:
- Build the `hypnos` binary.
- Run the tests using `nix flake check`.

This will help ensure consistent builds and test execution across different environments.